### PR TITLE
添加 headers={"Accept-Encoding": "identity"}禁用压缩

### DIFF
--- a/nonebot_plugin_moellmchats/Categorize.py
+++ b/nonebot_plugin_moellmchats/Categorize.py
@@ -41,6 +41,7 @@ internet_required: 布尔值，表示是否需要访问互联网或外部数据�
         headers = {
             "Authorization": model_selector.get_model("category_model")["key"],
             "Content-Type": "application/json",
+            "Accept-Encoding": "identity",
         }
         for try_times in range(2):
             try:

--- a/nonebot_plugin_moellmchats/Search.py
+++ b/nonebot_plugin_moellmchats/Search.py
@@ -13,6 +13,7 @@ class Search:
         headers = {
             "Content-Type": "application/json",
             "Authorization": config_parser.get_config("search_api"),
+            "Accept-Encoding": "identity",
         }
         data = {
             "query": self.plain,

--- a/nonebot_plugin_moellmchats/moe_llm.py
+++ b/nonebot_plugin_moellmchats/moe_llm.py
@@ -266,6 +266,7 @@ class MoeLlm:
         headers = {
             "Authorization": self.model_info["key"],
             "Content-Type": "application/json",
+            "Accept-Encoding": "identity",
         }
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=300)


### PR DESCRIPTION
为了在使用中转API时避免 zstd 问题；强制服务器返回未压缩内容。

`The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/vol2/1000/MCSManager/daemon/ikaros-bot/.venv/lib/python3.12/site-packages/nonebot_plugin_moellmchats/Categorize.py", line 57, in get_category
    response = await resp.json()
               ^^^^^^^^^^^^^^^^^
  File "/vol2/1000/MCSManager/daemon/ikaros-bot/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 753, in json
    await self.read()
  File "/vol2/1000/MCSManager/daemon/ikaros-bot/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 695, in read
    self._body = await self.content.read()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/vol2/1000/MCSManager/daemon/ikaros-bot/.venv/lib/python3.12/site-packages/aiohttp/streams.py", line 400, in read
    raise self._exception
aiohttp.client_exceptions.ClientPayloadError: 400, message:
  Can not decode content-encoding: zstd`